### PR TITLE
Make all process_* functions "static"

### DIFF
--- a/Kaitai/Stream.pm
+++ b/Kaitai/Stream.pm
@@ -272,7 +272,6 @@ sub read_strz {
 # ========================================================================
 
 sub process_xor_one {
-    my $self = shift;
     my $data = shift;
     my $key = shift;
 
@@ -283,7 +282,6 @@ sub process_xor_one {
 }
 
 sub process_xor_many {
-    my $self = shift;
     my $data = shift;
     my $key = shift;
     my $ki = 0;
@@ -298,7 +296,6 @@ sub process_xor_many {
 }
 
 sub process_rotate_left {
-    my $self = shift;
     my $data = shift;
     my $amount = shift;
     my $group_size = shift;


### PR DESCRIPTION
That is, they will be called without `$self` as a first argument.

Doesn't seem to fix the actual functions - it seems that `substr(...)` trick coped with `length()` results in infinite loop.
